### PR TITLE
Added auto-start of a flask application for pytest-selenium.

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,30 @@
+import multiprocessing
+import time
+import requests
+from app import app
+import pytest
+
+def run_app():
+    app.run(port=5000)
+
+@pytest.fixture(scope='session', autouse=True)
+def flask_server():
+    proc = multiprocessing.Process(target=run_app)
+    proc.start()
+    time.sleep(1)
+
+    # Wait until the server is up
+    for _ in range(10):
+        try:
+            requests.get("http://localhost:5000")
+            break
+        except requests.ConnectionError:
+            time.sleep(0.5)
+    else:
+        proc.terminate()
+        raise RuntimeError("Flask server did not start")
+
+    yield
+
+    proc.terminate()
+    proc.join()


### PR DESCRIPTION
Selenium test can run without having to start the flask server manually from a different console.

![image](https://github.com/user-attachments/assets/573a848f-2005-4f4b-93cb-7b0a763e00da)
